### PR TITLE
Feat: Build REST api endpoint for single bucket list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,10 @@
 #### Description of Task to be completed?
 
 #### How should this be manually tested?
-
+- Git fetch <origin/branch_name> and checkout to <branch_name>
+- Install deps
+- Fire Server: `yarn dev`
+- Make a request to http://localhost:<PORT>/api/v1/<path>
 #### Any background context you want to provide?
 
 #### What are the relevant pivotal tracker stories?

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:watch": "babel --watch src --out-dir dist --extensions '.ts,.tsx'",
     "build": "babel src --out-dir dist --extensions '.ts,.tsx'",
     "lint": "eslint src/**/**",
-    "lint:fix": "eslint src/**/** --fix",
+    "lint:fix": "eslint src/**/**/** --fix",
     "test": "jest",
     "test:cov": "jest --coverageReporters=text-lcov | coveralls",
     "test:watch": "jest --watch",

--- a/src/controllers/BucketlistController.ts
+++ b/src/controllers/BucketlistController.ts
@@ -10,6 +10,15 @@ class BucketlistController {
       return res.json({ status: 500, message: 'Something went wrong' });
     }
   }
+
+  static async fetchABucketlist(req, res) {
+    try {
+      const bucketlist = await BucketlistService.getABucketlist(req.params.id);
+      return res.json({ status: 200, data: [bucketlist] });
+    } catch (e) {
+      return res.json({ status: 500, message: 'Something went wrong' });
+    }
+  }
 }
 
 export default BucketlistController;

--- a/src/routes/bucketlist/bucketlist.spec.ts
+++ b/src/routes/bucketlist/bucketlist.spec.ts
@@ -5,12 +5,21 @@ describe('Bucketlists API test', () => {
   let request;
   beforeAll(() => {
     request = supertest(app);
-  })
+  });
   describe('Fetch all bucketlists', () => {
     it('should return all bucketlists', async () => {
       const response = await request.get('/api/v1/bucketlists');
       expect(Array.isArray(response.body.data)).toEqual(true);
       expect(response.body.status).toEqual(200);
-    })
-  })
-})
+    });
+  });
+
+  describe('Fetch a single bucketlist', () => {
+    it('should return a single bucketlist', async () => {
+      const response = await request.get('/api/v1/bucketlists/1');
+      expect(Array.isArray(response.body.data)).toEqual(true);
+      expect(response.body.data[0]).toBe(null);
+      expect(response.body.status).toEqual(200);
+    });
+  });
+});

--- a/src/routes/bucketlist/bucketlist.ts
+++ b/src/routes/bucketlist/bucketlist.ts
@@ -4,5 +4,6 @@ import BucketlistController from '../../controllers/BucketlistController';
 const bucketlistRouter = Router();
 
 bucketlistRouter.get('/bucketlists', BucketlistController.fetchAll);
+bucketlistRouter.get('/bucketlists/:id', BucketlistController.fetchABucketlist);
 
 export default bucketlistRouter;

--- a/src/services/BucketlistService.ts
+++ b/src/services/BucketlistService.ts
@@ -4,6 +4,10 @@ class BucketlistService {
   static getAllBucketlists() {
     return Bucketlist.findAll();
   }
+
+  static getABucketlist(id: string) {
+    return Bucketlist.findByPk(id);
+  }
 }
 
 export default BucketlistService;


### PR DESCRIPTION
#### What does this PR do?
- This PR builds a REST API endpoint for fetching a single bucket list
#### Description of Task to be completed?
- Build a single REST API endpoint for fetching a single bucket list
#### How should this be manually tested?
- Git fetch `origin/feat/view-single-bucket-list-item` and checkout to `feat/view-single-bucket-list-item`
- Install deps
- Fire Server: `yarn dev`
- Make a request to `http://localhost:<PORT>/api/v1/bucketlists/<bucket_list_id>`
- You should get a successful response with the bucket list of id: bucket_list_id
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168682893](https://www.pivotaltracker.com/story/show/168682893)
#### Screenshots (if appropriate)

